### PR TITLE
Implementations `version_setup`  function

### DIFF
--- a/R/version_setup.R
+++ b/R/version_setup.R
@@ -17,7 +17,7 @@ version_setup <- function(quiet = FALSE){
     # add options for the user 
     options <- c("Yes", "No")
     # prompt the choice for the user 
-    choice <- menu(options, title="To avoid data lost, it is good practice to have a backup of your raw data outside your repository before versioning.\nHave you backed up your data?")
+    choice <- menu(options, title="To avoid data loss, it is good practice to have a backup of your raw data outside your repository before versioning.\nHave you backed up your data?")
     if (choice == 2){
       stop("Please backup your data before versioning")
     }


### PR DESCRIPTION
Add a couple of lines in `version_setup` to:
- Check that the user has backed up the raw data before versioning. This opens a menu option and if the answer is "no", the function stops. Set as yes when run noni-interactively to ensure the correct building of vignettes etc.
- Check that the content of the original folders `data/raw` and `data/intermediate` is the same as the new ones. 